### PR TITLE
rename assert_taskgraph_result_output to assert_workflow_merged_result

### DIFF
--- a/ewoksppf/tests/test_examples.py
+++ b/ewoksppf/tests/test_examples.py
@@ -5,7 +5,7 @@ from ewokscore import load_graph
 from ewokscore.tests.examples.graphs import graph_names
 from ewokscore.tests.examples.graphs import get_graph
 from ewokscore.tests.utils import assert_taskgraph_result
-from ewokscore.tests.utils import assert_taskgraph_result_output
+from ewokscore.tests.utils import assert_workflow_merged_result
 
 # Logging makes multiprocessing hangs?
 # https://pythonspeed.com/articles/python-multiprocessing/
@@ -23,11 +23,12 @@ def test_execute_graph(graph_name, persist, ppf_logging, tmpdir):
     ewoksgraph = load_graph(g)
     if ewoksgraph.is_cyclic:
         result = execute_graph(g, varinfo=varinfo)
-        assert_taskgraph_result_output(result, expected, varinfo)
+        assert_workflow_merged_result(result, expected, varinfo)
     else:
-        if not persist:
+        execute_graph(g, varinfo=varinfo)
+        if persist:
+            assert_taskgraph_result(g, expected, varinfo=varinfo)
+        else:
             pytest.skip(
                 "The expected result is the output of each task when the binding gives the output of the workflow"
             )
-        execute_graph(g, varinfo=varinfo)
-        assert_taskgraph_result(g, expected, varinfo=varinfo)

--- a/ewoksppf/tests/test_ppf_workflow10.py
+++ b/ewoksppf/tests/test_ppf_workflow10.py
@@ -1,7 +1,7 @@
 import itertools
 import pytest
 from ewoksppf import execute_graph
-from ewokscore.tests.utils import assert_taskgraph_result_output
+from ewokscore.tests.utils import assert_workflow_merged_result
 
 
 def workflow10(inputs):
@@ -61,7 +61,7 @@ def test_workflow10(limit, persistent, ppf_logging, tmpdir):
     graph, expected = workflow10(inputs)
     result = execute_graph(graph, varinfo=varinfo)
     if persistent:
-        assert_taskgraph_result_output(result, expected, varinfo)
+        assert_workflow_merged_result(result, expected, varinfo)
     else:
         assert len(tmpdir.listdir()) == 0
         for k in expected:


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 23, 2021, 15:02 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksppf/-/merge_requests/11*