### PR TITLE
Mongodb log fixes

### DIFF
--- a/ewoksppf/bindings.py
+++ b/ewoksppf/bindings.py
@@ -81,6 +81,17 @@ class EwoksPythonActor(PythonActor):
         inData[infokey]["node_attrs"] = self.node_attrs
         return super().trigger(inData)
 
+    def uploadInDataToMongo(self, **kw):
+        task_identifier = self.node_attrs.get("task_identifier")
+        if task_identifier:
+            kw["script"] = task_identifier
+            super().uploadInDataToMongo(**kw)
+
+    def uploadOutDataToMongo(self, **kw):
+        task_identifier = self.node_attrs.get("task_identifier")
+        if task_identifier:
+            super().uploadOutDataToMongo(**kw)
+
 
 class ConditionalActor(AbstractActor):
     """Triggers downstream actors when conditions are fulfilled."""


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 20, 2022, 12:55 GMT+1:***

Requested by @olofsvensson 

Use node is as actor name:

```
workflow14/submodel14b/submodel14a/addtask2ab
```

Use task identifier as "script" for execution logging (mongo):

```
ewoksppf.tests.test_ppf_actors.pythonActorAdd.run
```

**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksppf/-/merge_requests/50*