### PR TITLE
silx does not build on python 3.6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,14 +2,14 @@ include:
   - project: workflow/ewoksadmin/ewoksci
     file: .gitlab-ci-template.yml
 
-test-3.6:
-  extends: .test-3.6
+test-3.7:
+  extends: .test-3.7
 
 build_sdist:
   extends: .build_sdist
 
-test_sdist-3.6:
-  extends: .test_sdist-3.6
+test_sdist-3.7:
+  extends: .test_sdist-3.7
 
 test_sdist-3.8-win:
   extends: .test_sdist-3.8-win


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 27, 2023, 09:32 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksppf/-/merge_requests/77*