### PR TITLE
Resolve "PYPUSHFLOW_OBJECTID (or the db_options) should get the workflow job id"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+Changes:
+
 - Drop Python 3.6 and 3.7
+- Set deprecated environment variable `PYPUSHFLOW_OBJECTID` to the Ewoks job id when needed.
 
 ## 1.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 requires-python = ">=3.8"
-dependencies = ["ewokscore >=1.0.0", "pypushflow >=1.0.0"]
+dependencies = ["ewokscore >=1.0.0", "pypushflow >=1.1.0"]
 
 [project.urls]
 Homepage = "https://gitlab.esrf.fr/workflow/ewoks/ewoksppf/"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 13, 2025, 15:04 GMT+1:***

Closes #19 

When `execute_graph` sees that the deprecated `PYPUSHFLOW_OBJECTID` is required, it sets it to the ewoks job id.

```
export PYPUSHFLOW_MONGOURL="mongodb://bes:bes@besdb1.esrf.fr:27017/bes"

ewoks execute demo --test --engine ppf

###################################
# Execute workflow 'demo'
###################################
2025-02-13 16:22:15,237 - pypushflow.persistence.besdb - WARNING  - '50d67039-66e0-495e-b07b-50fd5b291d0e' is not a valid BSON Object ID. Use its hash '63bd4ea06ba9ae7a9e3164ee' instead.
FINISHED
```

http://besgui.esrf.fr/actorPage/63bd4ea06ba9ae7a9e3164ee/scisoft10:38280

Needs https://gitlab.esrf.fr/workflow/pypushflow/-/merge_requests/89 (pypushflow 1.1.0)

**Assignees:** @woutdenolf

**Reviewers:** @olofsvensson

**Approved by:** @olofsvensson

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewoksppf/-/merge_requests/115*